### PR TITLE
Disabled externalizing dependencies when serving sandbox environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   ],
   "scripts": {
     "serve": "vue-cli-service serve --open",
-    "build": "vue-cli-service build",
-    "build-bundle": "vue-cli-service build --target lib ./src/index.js",
+    "build": "vue-cli-service build --target lib ./src/index.js",
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit"
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,10 +1,9 @@
 module.exports = {
   runtimeCompiler: true,
   configureWebpack: {
-    externals: [
-      'moment',
-      'velocity-animate',
-      'vue'
-    ]
+    externals: (process.env.NODE_ENV === 'production') ? {
+      moment: 'moment',
+      'velocity-animate': 'velocity-animate'
+    } : {}
   }
 }


### PR DESCRIPTION
Currently when you are running the serve script you are getting an empty page because Vue is missing. This is because we externalize third party libraries to save disk space.

I improved the config so you can use the serve and build script without messing with the config.

I also removed the build script and renamed build-bundle to build. I dont think we need the old build script for anything. It is only confusing.