### PR TITLE
Fix modal loading exception

### DIFF
--- a/src/Modal/VaModal.vue
+++ b/src/Modal/VaModal.vue
@@ -219,7 +219,8 @@
         const body = document.body
         const scrollBarWidth = getScrollBarWidth()
         if (val) {
-          el.querySelector('.' + this.classPrefix + '-modal-content').focus()
+          if (!this.modalIsLoading)
+            el.querySelector('.' + this.classPrefix + '-modal-content').focus()
           el.style.display = 'block'
           // this timeout is required for opacity transition
           setTimeout(() => {


### PR DESCRIPTION
Don't focus content when loading is true, because content element does not exist at this moment so it fails with:
`Error in callback for watcher "isShow": "TypeError: el.querySelector(...) is null"`

**What kind of changes does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes:
- [ ] Other,please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] All tests are passing
- [ ] New/updated tests are included
