### PR TITLE
feat(modal): modal handles loading state more smoothly

### DIFF
--- a/src/Modal/VaModal.vue
+++ b/src/Modal/VaModal.vue
@@ -1,42 +1,43 @@
 <template>
-    <div :class="classObj" :style="styleObj" ref="modal">
-        <div :class="`${classPrefix}-modal-dialog`" :style="{'width': width }">
-            <div :class="`${classPrefix}-modal-loading`" v-if="modalIsLoading">
-                <va-loading color="#888" size="md"></va-loading>
-            </div>
+  <div :class="classObj" :style="styleObj" ref="modal">
+    <div :class="`${classPrefix}-modal-dialog`" :style="{'width': width }">
 
-            <div :class="`${classPrefix}-modal-content`" v-else>
-
-                <slot name="header">
-                    <div :class="`${classPrefix}-modal-header`">
-                        <va-button tabindex="-1" :class="`${classPrefix}-close`" @click="close" type="subtle">
-                            <va-icon type="times"></va-icon>
-                        </va-button>
-                        <div :class="`${classPrefix}-modal-title`">
-                            <slot name="title">
-                                {{title}}
-                            </slot>
-                        </div>
-                    </div>
-                </slot>
-
-                <div :class="`${classPrefix}-modal-body`">
-                    <slot name="body"/>
-                </div>
-
-                <div :class="`${classPrefix}-modal-footer`">
-                    <slot name="footer">
-                        <va-button :focused="focused" @click.native="confirm" type="primary">
-                            {{getL('confirm')}}
-                        </va-button>
-                        <va-button @click.native="close" type="subtle">
-                            {{getL('cancel')}}
-                        </va-button>
-                    </slot>
-                </div>
-            </div>
+      <va-collapse-transition>
+        <div :class="`${classPrefix}-modal-loading`" v-show="modalIsLoading">
+          <va-loading color="#888" size="md"></va-loading>
         </div>
+      </va-collapse-transition>
+
+      <div :class="`${classPrefix}-modal-content`" v-show="!modalIsLoading">
+        <slot name="header">
+          <div :class="`${classPrefix}-modal-header`">
+            <va-button tabindex="-1" :class="`${classPrefix}-close`" @click="close" type="subtle">
+              <va-icon type="times"></va-icon>
+            </va-button>
+            <div :class="`${classPrefix}-modal-title`">
+              <slot name="title">
+                {{title}}
+              </slot>
+            </div>
+          </div>
+        </slot>
+        <div :class="`${classPrefix}-modal-body`">
+          <slot name="body" />
+        </div>
+        <div :class="`${classPrefix}-modal-footer`">
+          <slot name="footer">
+            <va-button :focused="focused" @click.native="confirm" type="primary">
+              {{getL('confirm')}}
+            </va-button>
+            <va-button @click.native="close" type="subtle">
+              {{getL('cancel')}}
+            </va-button>
+          </slot>
+        </div>
+      </div>
+
     </div>
+  </div>
 </template>
 
 <script>
@@ -155,6 +156,13 @@
       })
     },
     watch: {
+      modalIsLoading(val) {
+        if (!val) {
+          setTimeout(() => {
+            this.focusTrap.activate()
+          }, 50)
+        }
+      },
       isShow(val) {
         /**
          * Stackable logic
@@ -179,7 +187,7 @@
                  * then we simply double the value by whatever it
                  * already is.
                  */
-                  // Slice 'px' off from the end.
+                // Slice 'px' off from the end.
                 let m = Math.abs(currentMarginLeft.slice(0, -2))
                 let dist = parseInt(m + distanceToMove)
                 x[i].style['margin-left'] = '-' + dist + 'px'
@@ -236,7 +244,9 @@
             })
           }
 
-          this.focusTrap.activate()
+          if (!this.modalIsLoading) {
+            this.focusTrap.activate()
+          }
         } else {
           if (this._blurModalContentEvent) this._blurModalContentEvent.remove()
           element.removeClass(el, this.classPrefix + '-modal-in')

--- a/src/style/_modal.scss
+++ b/src/style/_modal.scss
@@ -86,7 +86,12 @@ $modalBoxShadow) {
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 10px 0;
+    padding: 30px 0;
+
+    .#{$class-prefix}-page-loading-con {
+      display: table;
+      margin: 0 auto;
+    }
   }
 
   &-header {


### PR DESCRIPTION
<!-- Change "[ ]" to "[x]" to check a checkbox -->

**What kind of changes does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes:
- [ ] Other,please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature

**Other information:**

when the modal has finished loading, as indicated by the `modalIsLoading` prop, focus **then** becomes trapped. otherwise, modal behavior has not changed.

also, the loading element was wrapped in a va-collapse-transition. see gif below for how this looks.

before focus trap fix and collapse transition
![modalbefore](https://user-images.githubusercontent.com/17074357/53291822-585e0e00-376e-11e9-90c6-abd0e4fa5260.gif)


after:
![modalafter](https://user-images.githubusercontent.com/17074357/53291826-5c8a2b80-376e-11e9-8795-ee6c480d8337.gif)


