### PR TITLE
fix(button): when button is both `active` and `loading`, the spinner …

### DIFF
--- a/src/Button/VaButton.vue
+++ b/src/Button/VaButton.vue
@@ -151,9 +151,13 @@
     },
     computed: {
       spinColor () {
-        let {type} = this
+        let {type, active} = this
         let white = '#FFFFFF'
         let darker = '#45526B'
+
+        if (active) {
+          return darker
+        }
 
         switch (type) {
           case 'default':


### PR DESCRIPTION
…color should always be dark.

<!-- Change "[ ]" to "[x]" to check a checkbox -->

**What kind of changes does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes:
- [ ] Other,please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature

**Other information:**

![activeloadingspinner](https://user-images.githubusercontent.com/17074357/53295357-5e73df00-37ae-11e9-9fab-211fb6f07659.gif)

