### PR TITLE
feat(modal): warning/danger alert/confirm modals have buttons that match

### DIFF
--- a/src/Modal/VaModalMethod.js
+++ b/src/Modal/VaModalMethod.js
@@ -17,17 +17,32 @@ const typeMap = {
     name: 'check',
     color: '#57D9A3'
   },
-  danger: {
-    name: 'exclamation-triangle',
-    color: '#CD4425'
+  info: {
+    name: 'info',
+    color: '#4C9AFF'
   },
   warning: {
     name: 'exclamation-triangle',
     color: '#F29D41'
   },
+  danger: {
+    name: 'exclamation-triangle',
+    color: '#CD4425'
+  }
+}
+
+const buttonTypeMap = {
+  success: {
+    appearance: 'primary'
+  },
   info: {
-    name: 'info',
-    color: '#4C9AFF'
+    appearance: 'primary'
+  },
+  warning: {
+    appearance: 'warning'
+  },
+  danger: {
+    appearance: 'danger'
   }
 }
 
@@ -36,12 +51,16 @@ const confirm = (options) => {
   /* eslint-disable no-new */
   new Vue({
     el: createNode(),
+    mixins: [localeMixin('VaModal')],
     mounted () {
       this.$refs.modal.open()
     },
     computed: {
       iconType () {
         return typeMap[type || 'info']
+      },
+      buttonType () {
+        return buttonTypeMap[type || 'primary']
       }
     },
     methods: {
@@ -80,6 +99,17 @@ const confirm = (options) => {
         ])
       }
       let bodyElement = createElement('div', { slot: 'body', domProps: { innerHTML: message } })
+
+      let footerElement = createElement(VaButton, {
+        slot: 'footer',
+        props: {
+          type: this.buttonType.appearance
+        },
+        on: {
+          click: this.handleConfirm
+        }
+      }, [this.getL('confirm')])
+
       return createElement(VaModal, {
         ref: 'modal',
         props: {
@@ -96,7 +126,8 @@ const confirm = (options) => {
         }
       }, [
         titleElement,
-        bodyElement
+        bodyElement,
+        footerElement
       ])
     }
   })
@@ -114,6 +145,9 @@ const alert = (options) => {
     computed: {
       iconType () {
         return typeMap[type || 'info']
+      },
+      buttonType () {
+        return buttonTypeMap[type || 'primary']
       }
     },
     methods: {
@@ -158,7 +192,7 @@ const alert = (options) => {
       let footerElement = createElement(VaButton, {
         slot: 'footer',
         props: {
-          type: 'primary'
+          type: this.buttonType.appearance
         },
         on: {
           click: this.handleConfirm


### PR DESCRIPTION
<!-- Change "[ ]" to "[x]" to check a checkbox -->

**What kind of changes does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes:
- [ ] Other,please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature

**Other information:**

confirm and alert modals of type 'warning' or 'danger' have buttons that
match the appearance of the icon and type of modal. all other modals still use
the usual 'primary' button appearance

a confirm modal of type 'danger' before:
<img width="603" alt="modalappearancebefore" src="https://user-images.githubusercontent.com/17074357/53304243-be5a9c00-3827-11e9-97d5-3ef95d9e4783.png">

and after:
<img width="606" alt="modalappearanceafter" src="https://user-images.githubusercontent.com/17074357/53304246-c31f5000-3827-11e9-819f-e9e4bf8df48d.png">


