### PR TITLE
Apply validation status styles on Textarea

### DIFF
--- a/src/Textarea/VaTextarea.vue
+++ b/src/Textarea/VaTextarea.vue
@@ -31,6 +31,7 @@
 
     <validate
       :name="name"
+      v-model="validStatus"
       :rules="rules"
       :custom-validate="customValidate"
       :current="value"
@@ -313,13 +314,17 @@ export default {
 
       style['width'] = width
       style['min-height'] = minHeight
+      style['position'] = 'relative'
 
       return style
     },
     classObjContainer () {
-      let { classPrefix } = this
+      let { classPrefix, validStatus } = this
       let classes = {}
 
+      classes[classPrefix + '-has-error'] = validStatus === 'error'
+      classes[classPrefix + '-has-success'] = validStatus === 'success'
+      classes[classPrefix + '-has-warn'] = validStatus === 'warn'
       classes[classPrefix + '-textarea-con'] = true
       // classes['inline'] = true
 
@@ -331,7 +336,6 @@ export default {
 
 <style lang="scss">
 .#{$class-prefix}-textarea-con {
-  overflow-y: hidden;
   .#{$class-prefix}-form-control {
     line-height: 16px;
   }


### PR DESCRIPTION
Textarea ignored validation status before.
Also there is required `position: relative` for wrapper, otherwise validation tip will has offset (because of absolute position). Also I'm not sure it's okay to remove overflow, with overflowing tip is also hidden and textarea bottom border is half cut.
<img width="474" alt="изображение" src="https://user-images.githubusercontent.com/24208746/59941965-38620100-9467-11e9-99af-64fe75b273c4.png">
