### PR TITLE
Import reset.scss as scoped style to avoid conflict with other libs/apps

### DIFF
--- a/src/Affix/VaAffix.vue
+++ b/src/Affix/VaAffix.vue
@@ -24,6 +24,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 .va-affix {
   position: sticky;

--- a/src/Alert/VaAlert.vue
+++ b/src/Alert/VaAlert.vue
@@ -70,6 +70,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/App/VaAppConfig.vue
+++ b/src/App/VaAppConfig.vue
@@ -477,7 +477,9 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
+@import "../style/_reset.scss";
+</style><style lang="scss">
 .themeModalBody {
   hr {
     margin-top: 0px;

--- a/src/Aside/VaAside.vue
+++ b/src/Aside/VaAside.vue
@@ -147,6 +147,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Badge/VaBadge.vue
+++ b/src/Badge/VaBadge.vue
@@ -43,6 +43,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Breadcrumb/VaBreadcrumb.vue
+++ b/src/Breadcrumb/VaBreadcrumb.vue
@@ -27,6 +27,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Button/VaButton.vue
+++ b/src/Button/VaButton.vue
@@ -304,6 +304,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Card/VaCard.vue
+++ b/src/Card/VaCard.vue
@@ -74,6 +74,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Checkbox/VaCheckbox.vue
+++ b/src/Checkbox/VaCheckbox.vue
@@ -114,6 +114,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Collapse/VaCollapse.vue
+++ b/src/Collapse/VaCollapse.vue
@@ -42,6 +42,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Datepicker/VaDatepicker.vue
+++ b/src/Datepicker/VaDatepicker.vue
@@ -624,6 +624,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Dropdown/VaDropdown.vue
+++ b/src/Dropdown/VaDropdown.vue
@@ -108,6 +108,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Icon/VaIcon.vue
+++ b/src/Icon/VaIcon.vue
@@ -69,7 +69,9 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
+@import "../style/_reset.scss";
+</style><style lang="scss">
 @import "../variables";
 @import "../style/font";
 </style>

--- a/src/Lozenge/VaLozenge.vue
+++ b/src/Lozenge/VaLozenge.vue
@@ -65,6 +65,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Minibar/VaMinibar.vue
+++ b/src/Minibar/VaMinibar.vue
@@ -271,6 +271,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 @import "../style/bars";

--- a/src/Mixin/popoverMixin.js
+++ b/src/Mixin/popoverMixin.js
@@ -151,7 +151,7 @@ const PopoverMixin = {
           this.position.top = triger.offsetTop + triger.offsetHeight
           break
         default:
-          console.error('Wrong placement group')
+          break
       }
       popover.style.top = this.position.top + 'px'
       popover.style.left = this.position.left + 'px'

--- a/src/Modal/VaModal.vue
+++ b/src/Modal/VaModal.vue
@@ -285,6 +285,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Notification/VaNotification.vue
+++ b/src/Notification/VaNotification.vue
@@ -212,6 +212,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Page/VaPage.vue
+++ b/src/Page/VaPage.vue
@@ -212,6 +212,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Placeholder/VaPlaceholder.vue
+++ b/src/Placeholder/VaPlaceholder.vue
@@ -37,6 +37,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/ProgressTracker/VaProgressTracker.vue
+++ b/src/ProgressTracker/VaProgressTracker.vue
@@ -67,6 +67,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Radio/VaRadio.vue
+++ b/src/Radio/VaRadio.vue
@@ -111,6 +111,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Range/VaRange.vue
+++ b/src/Range/VaRange.vue
@@ -190,6 +190,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Select/VaSelect.vue
+++ b/src/Select/VaSelect.vue
@@ -490,6 +490,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 @import "../style/animate";

--- a/src/Sidebar/VaSidebar.vue
+++ b/src/Sidebar/VaSidebar.vue
@@ -217,6 +217,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 @import "../style/bars";

--- a/src/Table/VaTable.vue
+++ b/src/Table/VaTable.vue
@@ -36,6 +36,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Tabs/VaTabs.vue
+++ b/src/Tabs/VaTabs.vue
@@ -151,6 +151,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Timepicker/VaTimepicker.vue
+++ b/src/Timepicker/VaTimepicker.vue
@@ -272,6 +272,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Toast/VaToast.vue
+++ b/src/Toast/VaToast.vue
@@ -101,6 +101,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Toggle/VaToggle.vue
+++ b/src/Toggle/VaToggle.vue
@@ -78,6 +78,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Tooltip/VaTooltip.vue
+++ b/src/Tooltip/VaTooltip.vue
@@ -47,6 +47,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 

--- a/src/Topbar/VaTopbar.vue
+++ b/src/Topbar/VaTopbar.vue
@@ -323,6 +323,7 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../style/_reset.scss" scoped></style>
 <style lang="scss">
 @import "../variables";
 @import "../style/bars";

--- a/src/style/_common.scss
+++ b/src/style/_common.scss
@@ -17,7 +17,7 @@
 @import 'toast';
 @import 'affix';
 @import 'input';
-@import 'reset';
+// @import 'reset';
 @import 'modal';
 @import 'toggle';
 @import 'select';

--- a/src/style/_reset.scss
+++ b/src/style/_reset.scss
@@ -1,85 +1,85 @@
-html {
+::v-deep html {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
 }
 
-body {
+::v-deep body {
   margin: 0;
   // -webkit-font-smoothing: antialiased;
 }
 
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-menu,
-nav,
-section,
-summary {
+::v-deep article,
+::v-deep aside,
+::v-deep details,
+::v-deep figcaption,
+::v-deep figure,
+::v-deep footer,
+::v-deep header,
+::v-deep hgroup,
+::v-deep main,
+::v-deep menu,
+::v-deep nav,
+::v-deep section,
+::v-deep summary {
   display: block;
 }
 
-audio,
-canvas,
-progress,
-video {
+::v-deep audio,
+::v-deep canvas,
+::v-deep progress,
+::v-deep video {
   display: inline-block;
   vertical-align: baseline;
 }
 
-b,
-strong {
+::v-deep b,
+::v-deep strong {
   font-weight: bold;
 }
 
-img {
+::v-deep img {
   border: 0;
 }
 
-svg:not(:root) {
+::v-deep svg:not(:root) {
   overflow: hidden;
 }
 
-button {
+::v-deep button {
   overflow: visible;
 }
 
-button,
-select {
+::v-deep button,
+::v-deep select {
   text-transform: none;
 }
 
-button,
-html input[type="button"],
-input[type="reset"],
-input[type="submit"] {
+::v-deep button,
+::v-deep html input[type="button"],
+::v-deep input[type="reset"],
+::v-deep input[type="submit"] {
   -webkit-appearance: button;
   cursor: pointer;
 }
 
-button[disabled],
-html input[disabled] {
+::v-deep button[disabled],
+::v-deep html input[disabled] {
   cursor: default;
 }
 
-button::-moz-focus-inner,
-input::-moz-focus-inner {
+::v-deep button::-moz-focus-inner,
+::v-deep input::-moz-focus-inner {
   padding: 0;
   border: 0;
 }
 
-input {
+::v-deep input {
   line-height: normal;
 }
 
-input[type="checkbox"],
-input[type="radio"] {
+::v-deep input[type="checkbox"],
+::v-deep input[type="radio"] {
   box-sizing: border-box;
   padding: 0;
   margin: 4px 0 0;
@@ -87,48 +87,48 @@ input[type="radio"] {
   line-height: normal;
 }
 
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
+::v-deep input[type="number"]::-webkit-inner-spin-button,
+::v-deep input[type="number"]::-webkit-outer-spin-button {
   height: auto;
 }
 
-input[type="search"] {
+::v-deep input[type="search"] {
   box-sizing: border-box;
   -webkit-appearance: textfield;
 }
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
+::v-deep input[type="search"]::-webkit-search-cancel-button,
+::v-deep input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-input[type="file"] {
+::v-deep input[type="file"] {
   display: block;
 }
 
-input[type="range"] {
+::v-deep input[type="range"] {
   display: block;
   width: 100%;
 }
 
-select[multiple],
-select[size] {
+::v-deep select[multiple],
+::v-deep select[size] {
   height: auto;
 }
 
-input[type="file"]:focus,
-input[type="radio"]:focus,
-input[type="checkbox"]:focus {
+::v-deep input[type="file"]:focus,
+::v-deep input[type="radio"]:focus,
+::v-deep input[type="checkbox"]:focus {
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
 
-* {
+::v-deep * {
   box-sizing: border-box;
 }
 
-*:before,
-*:after {
+::v-deep *:before,
+::v-deep *:after {
   box-sizing: border-box;
 }

--- a/src/style/default.scss
+++ b/src/style/default.scss
@@ -1,5 +1,5 @@
 // General
-@import 'reset';
+// @import 'reset';
 @import 'colors';
 @import 'font';
 @import 'utilities';

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,5 +1,5 @@
 @import './style/colors';
-@import './style/reset';
+// @import './style/reset';
 @import './style/utilities';
 @import './style/animate';
 @import './style/typography';


### PR DESCRIPTION
<!-- Change "[ ]" to "[x]" to check a checkbox -->

**What kind of changes does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes:
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature

**Other information:**
Hi,
Thanks a lot for your work on vue-atlas. 
I found that solution to avoid that the reset.scss break components from other apps/libs and I wanted to share it. I am not using vue-atlas in "full page" mode. I wanted the reset rules to be applied only in the scope of vue-atlas components. We should perhaps do it a bit differently, I do not know scss very well.
Thanks in advance to review this PR and thanks again for this really good lib! 
Cheers,
G
