### PR TITLE
[Minor] Use a random key instead of index for transition group in multiple mode for VaSelect

### DIFF
--- a/src/Select/VaSelect.vue
+++ b/src/Select/VaSelect.vue
@@ -20,7 +20,7 @@
           <transition-group name="fade" class="va-trans-group-flex">
             <div
               class="va-selected-tag va-selected-tag-multiple"
-              :key="index"
+              :key="Math.round(Math.random() * Number.MAX_SAFE_INTEGER)"
               @click.stop="del(item)"
               tabindex="0"
               v-for="(item, index) in selectedItems"


### PR DESCRIPTION
Use a random key instead of index for transition group in multiple mode for VaSelect. Fixes the warning: "Do not use v-for index as key on <transition-group> children, this is the same as not using keys."

**What kind of changes does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes:
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No