### PR TITLE
Fix: VaSelect - added value defined check to <button> conditional class

### DIFF
--- a/src/Select/VaSelect.vue
+++ b/src/Select/VaSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="classObj" :style="styleObj">
     <va-button
-      :class="[`va-dropdown-toggle`, `va-select-btn`, showSelected && multiple && value.length ? `va-select-multiple` : '', show ? `va-select-btn-open` : '']"
+      :class="[`va-dropdown-toggle`, `va-select-btn`, showSelected && multiple && typeof value !== 'undefined' && value.length ? `va-select-multiple` : '', show ? `va-select-btn-open` : '']"
       :disabled="disabled"
       :size="size"
       :style="{minWidth:'100%'}"


### PR DESCRIPTION
Not checking for ```value``` being defined leads to an error of ```length not present on undefined```

This manifests itself when the multiple flag is set on the VaSelect component.

Closes #165 

<!-- Change "[ ]" to "[x]" to check a checkbox -->

**What kind of changes does this PR introduce?** (check at least one)

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes:
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No